### PR TITLE
Testing background process with Dash Pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     environment:
-      - RUNNING_ENV=docker
+      - REDIS_URL=redis://dash-app-redis:6379
     depends_on:
       - "dash-app-redis"
     networks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,13 +289,13 @@ files = [
 
 [[package]]
 name = "dash"
-version = "2.15.0"
+version = "2.16.0"
 description = "A Python framework for building reactive web-apps. Developed by Plotly."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "dash-2.15.0-py3-none-any.whl", hash = "sha256:df1882bbf613e4ca4372281c8facbeb68e97d76720336b051bf84c75d2de8588"},
-    {file = "dash-2.15.0.tar.gz", hash = "sha256:d38891337fc855d5673f75e5346354daa063c4ff45a8a6a21f25e858fcae41c2"},
+    {file = "dash-2.16.0-py3-none-any.whl", hash = "sha256:2a06e3856d9389656e1c84d6afb086748db0bbb676f44abb899df117c2879606"},
+    {file = "dash-2.16.0.tar.gz", hash = "sha256:7887998e278f6cc1b8200ec9d9d6f82b5cb599997a31723c926487a25ce52117"},
 ]
 
 [package.dependencies]
@@ -305,7 +305,7 @@ dash-html-components = "2.0.0"
 dash-table = "5.0.0"
 diskcache = {version = ">=5.2.1", optional = true, markers = "extra == \"diskcache\""}
 Flask = ">=1.0.4,<3.1"
-importlib-metadata = {version = "*", markers = "python_version >= \"3.7\""}
+importlib-metadata = "*"
 multiprocess = {version = ">=0.70.12", optional = true, markers = "extra == \"diskcache\""}
 nest-asyncio = "*"
 plotly = ">=5.0.0"
@@ -318,8 +318,8 @@ typing-extensions = ">=4.1.1"
 Werkzeug = "<3.1"
 
 [package.extras]
-celery = ["celery[redis] (>=5.1.2)", "importlib-metadata (<5)", "redis (>=3.5.3)"]
-ci = ["black (==21.6b0)", "black (==22.3.0)", "dash-dangerously-set-inner-html", "dash-flow-example (==0.0.5)", "flake8 (==3.9.2)", "flaky (==3.7.0)", "flask-talisman (==1.0.0)", "isort (==4.3.21)", "jupyterlab (<4.0.0)", "mimesis (<=11.1.0)", "mock (==4.0.3)", "numpy (<=1.25.2)", "openpyxl", "orjson (==3.5.4)", "orjson (==3.6.7)", "pandas (==1.1.5)", "pandas (>=1.4.0)", "preconditions", "pyarrow", "pyarrow (<3)", "pylint (==2.13.5)", "pytest-mock", "pytest-rerunfailures", "pytest-sugar (==0.9.6)", "xlrd (<2)", "xlrd (>=2.0.1)"]
+celery = ["celery[redis] (>=5.1.2)", "redis (>=3.5.3)"]
+ci = ["black (==22.3.0)", "dash-dangerously-set-inner-html", "dash-flow-example (==0.0.5)", "flake8 (==7.0.0)", "flaky (==3.7.0)", "flask-talisman (==1.0.0)", "jupyterlab (<4.0.0)", "mimesis (<=11.1.0)", "mock (==4.0.3)", "numpy (<=1.26.3)", "openpyxl", "orjson (==3.9.12)", "pandas (>=1.4.0)", "pyarrow", "pylint (==3.0.3)", "pytest-mock", "pytest-rerunfailures", "pytest-sugar (==0.9.6)", "pyzmq (==25.1.2)", "xlrd (>=2.0.1)"]
 compress = ["flask-compress"]
 dev = ["PyYAML (>=5.4.1)", "coloredlogs (>=15.0.1)", "fire (>=0.4.0)"]
 diskcache = ["diskcache (>=5.2.1)", "multiprocess (>=0.70.12)", "psutil (>=5.8.0)"]
@@ -690,13 +690,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -704,17 +704,17 @@ six = ">=1.5"
 
 [[package]]
 name = "redis"
-version = "5.0.1"
+version = "5.0.2"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-5.0.1-py3-none-any.whl", hash = "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"},
-    {file = "redis-5.0.1.tar.gz", hash = "sha256:0dab495cd5753069d3bc650a0dde8a8f9edde16fc5691b689a566eda58100d0f"},
+    {file = "redis-5.0.2-py3-none-any.whl", hash = "sha256:4caa8e1fcb6f3c0ef28dba99535101d80934b7d4cd541bbb47f4a3826ee472d1"},
+    {file = "redis-5.0.2.tar.gz", hash = "sha256:3f82cc80d350e93042c8e6e7a5d0596e4dd68715babffba79492733e1f367037"},
 ]
 
 [package.dependencies]
-async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+async-timeout = ">=4.0.3"
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -892,4 +892,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "886863dde51a6733715860d730b2992b049776c6f1a0a5f02f47cbeff025a9b1"
+content-hash = "243dd4a6e568e75366348b8d1f60f304653ff50bfd0ee403b8edc46c049d951f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-dash = {extras = ["celery", "diskcache"], version = "^2.15.0"}
+dash = {extras = ["celery", "diskcache"], version = "^2.16.0"}
 gunicorn = "^21.2.0"
 
 

--- a/src/dash_app/app.py
+++ b/src/dash_app/app.py
@@ -2,8 +2,6 @@ import logging
 import os
 
 import dash
-import diskcache
-from celery import Celery
 from dash import Dash, DiskcacheManager, CeleryManager, html
 
 logger = logging.getLogger(__name__)
@@ -11,50 +9,42 @@ logger = logging.getLogger(__name__)
 # some constants
 DEFAULT_PORT: int = 7002
 REDIS_HOST = "redis://dash-app-redis:6379"
-DOCKER_ENV = "docker"
 
 # get the running environment
-RUNNING_ENV = os.environ.get("RUNNING_ENV")
+REDIS_URL_ENV_VAR = "REDIS_URL"
 
-# expose the celery app only if we are running in docker
-celery_app = Celery(
-    __name__,
-    broker=f"{REDIS_HOST}/0",
-    backend=f"{REDIS_HOST}/1",
-) if RUNNING_ENV == DOCKER_ENV else None
+if REDIS_URL_ENV_VAR in os.environ:
+    # Use Redis & Celery if REDIS_URL set as an env variable
+    from celery import Celery
 
-
-def get_background_callback_manager():
-    if RUNNING_ENV == DOCKER_ENV:
-        return CeleryManager(celery_app)
-    else:
-        return DiskcacheManager(diskcache.Cache("./cache"))
-
-
-# keep the background callback manager in a global variable
-_background_callback_manager = get_background_callback_manager()
-
-
-def get_app() -> Dash:
-    app = Dash(
-        name=__name__,
-        title="Dash POC",
-        background_callback_manager=_background_callback_manager,
-        use_pages=True
+    celery_app = Celery(
+        __name__,
+        broker=os.environ[REDIS_URL_ENV_VAR],
+        backend=os.environ[REDIS_URL_ENV_VAR]
     )
+    background_callback_manager = CeleryManager(celery_app=celery_app)
 
-    app.layout = html.Div(
-        dash.page_container
-    )
+else:
+    # Diskcache for non-production apps when developing locally
+    import diskcache
 
-    return app
+    cache = diskcache.Cache("./cache")
+    background_callback_manager = DiskcacheManager(cache=cache)
+
+app = Dash(
+    name=__name__,
+    title="Dash POC",
+    background_callback_manager=background_callback_manager,
+    use_pages=True
+)
+
+app.layout = html.Div(
+    dash.page_container
+)
 
 
 def main() -> None:
     logging.basicConfig(level=logging.DEBUG, force=True)
-    logger.info("Starting app")
-    app = get_app()
-
     logger.debug("Starting in development mode")
     app.run(
         debug=True,

--- a/src/dash_app/app.py
+++ b/src/dash_app/app.py
@@ -1,11 +1,10 @@
 import logging
 import os
-import time
 
-# import dash_bootstrap_components as dbc
+import dash
 import diskcache
 from celery import Celery
-from dash import Dash, DiskcacheManager, CeleryManager, Output, Input, callback, html
+from dash import Dash, DiskcacheManager, CeleryManager, html
 
 logger = logging.getLogger(__name__)
 
@@ -40,14 +39,12 @@ def get_app() -> Dash:
     app = Dash(
         name=__name__,
         title="Dash POC",
-        background_callback_manager=_background_callback_manager
+        background_callback_manager=_background_callback_manager,
+        use_pages=True
     )
 
     app.layout = html.Div(
-        [
-            html.Div([html.P(id="paragraph_id", children=["Button not clicked"])]),
-            html.Button(id="button_id", children="Run Job!"),
-        ]
+        dash.page_container
     )
 
     return app
@@ -63,21 +60,6 @@ def main() -> None:
         debug=True,
         port=DEFAULT_PORT
     )
-
-
-@callback(
-    Output("paragraph_id", "children"),
-    Input("button_id", "n_clicks"),
-    running=[
-        (Output("button_id", "disabled"), True, False),
-        (Output("button_id", "children"), "Running...", "Run Job!")
-    ],
-    background=True,
-    prevent_initial_call=True
-)
-def update_clicks(n_clicks):
-    time.sleep(2.0)
-    return [f"Clicked {n_clicks} times"]
 
 
 if __name__ == "__main__":

--- a/src/dash_app/pages/home.py
+++ b/src/dash_app/pages/home.py
@@ -1,0 +1,28 @@
+import time
+
+import dash
+from dash import html, Input, Output, callback
+
+dash.register_page(__name__, path='/')
+
+layout = html.Div(
+    [
+        html.Div([html.P(id="paragraph_id", children=["Button not clicked"])]),
+        html.Button(id="button_id", children="Run Job!"),
+    ]
+)
+
+
+@callback(
+    Output("paragraph_id", "children"),
+    Input("button_id", "n_clicks"),
+    running=[
+        (Output("button_id", "disabled"), True, False),
+        (Output("button_id", "children"), "Running...", "Run Job!")
+    ],
+    background=True,
+    prevent_initial_call=True
+)
+def update_clicks(n_clicks):
+    time.sleep(2.0)
+    return [f"Clicked {n_clicks} times"]

--- a/src/dash_app/wsgi.py
+++ b/src/dash_app/wsgi.py
@@ -1,5 +1,3 @@
 """Entrypoint for Gunicorn."""
-from dash_app.app import get_app
-
-app = get_app()
+from dash_app.app import app
 server = app.server


### PR DESCRIPTION
This branch is only working when running Dash in dev mode. When running with docker-compose, 
```
dash-app          | KeyError: 'long_callback_f98916ea2c1370ad25b2228f7f6889b98336cbb8'
```
because callback is not registered with Celery.